### PR TITLE
chore: rm shield go report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # cachekit
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/DucTran999/cachekit)](https://goreportcard.com/report/github.com/DucTran999/cachekit)
 [![Go](https://img.shields.io/badge/Go-1.23-blue?logo=go)](https://golang.org)
 [![codecov](https://codecov.io/gh/DucTran999/cachekit/graph/badge.svg?token=5XBMMBKCPD)](https://codecov.io/gh/DucTran999/cachekit)
 [![Known Vulnerabilities](https://snyk.io/test/github/ductran999/cachekit/badge.svg)](https://snyk.io/test/github/ductran999/cachekit)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the Go Report Card badge and its link from the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->